### PR TITLE
Update DataProvider.php

### DIFF
--- a/Ui/DataProvider/GuestOrders/DataProvider.php
+++ b/Ui/DataProvider/GuestOrders/DataProvider.php
@@ -16,9 +16,9 @@ class DataProvider extends AbstractDataProvider
 
     /**
      * DataProvider constructor.
-     * @param $name
-     * @param $primaryFieldName
-     * @param $requestFieldName
+     * @param string $name
+     * @param string $primaryFieldName
+     * @param string $requestFieldName
      * @param CollectionFactory $factory
      * @param StoreManagerInterface $storeManager
      * @param array $meta


### PR DESCRIPTION
compilation:
        Aashan\LinkGuestOrder\Ui\DataProvider\GuestOrders\DataProvider
                Incompatible argument type: Required type: string. Actual type:
\Aashan\LinkGuestOrder\Ui\DataProvider\GuestOrders\name; File:
vendor/aashan/module-link-guest-orders/Ui/DataProvider/GuestOrders/DataProvider.php